### PR TITLE
 Add exit diagnostic session

### DIFF
--- a/Caesar/Diogenes/DiagnosticProtocol/KW2C3PE.cs
+++ b/Caesar/Diogenes/DiagnosticProtocol/KW2C3PE.cs
@@ -21,6 +21,19 @@ namespace Diogenes.DiagnosticProtocol
             }
             return true;
         }
+        
+        private static bool ExitDiagnosticSession(ECUConnection connection)
+        {
+            Console.WriteLine("UDS: Switching session states");
+            byte[] sessionSwitchResponse = connection.SendMessage(new byte[] { 0x10, 0x81 });
+            byte[] sessionExpectedResponse = new byte[] { 0x50, 0x81 };
+            if (!sessionSwitchResponse.Take(2).SequenceEqual(sessionExpectedResponse))
+            {
+                Console.WriteLine($"Failed to switch session : target responded with [{BitUtility.BytesToHex(sessionSwitchResponse, true)}]");
+                return false;
+            }
+            return true;
+        }
 
         private static bool GetVariantID_1A86(ECUConnection connection, out int variantId)
         {

--- a/Caesar/Diogenes/DiagnosticProtocol/KW2C3PE.cs
+++ b/Caesar/Diogenes/DiagnosticProtocol/KW2C3PE.cs
@@ -24,7 +24,7 @@ namespace Diogenes.DiagnosticProtocol
         
         private static bool ExitDiagnosticSession(ECUConnection connection)
         {
-            Console.WriteLine("UDS: Switching session states");
+            Console.WriteLine("KW2C3PE: Switching session states");
             byte[] sessionSwitchResponse = connection.SendMessage(new byte[] { 0x10, 0x81 });
             byte[] sessionExpectedResponse = new byte[] { 0x50, 0x81 };
             if (!sessionSwitchResponse.Take(2).SequenceEqual(sessionExpectedResponse))

--- a/Caesar/Diogenes/DiagnosticProtocol/UDS.cs
+++ b/Caesar/Diogenes/DiagnosticProtocol/UDS.cs
@@ -166,6 +166,19 @@ namespace Diogenes.DiagnosticProtocol
             }
             return true;
         }
+        
+        private static bool ExitDiagnosticSession(ECUConnection connection)
+        {
+            Console.WriteLine("UDS: Switching session states");
+            byte[] sessionSwitchResponse = connection.SendMessage(new byte[] { 0x10, 0x01 });
+            byte[] sessionExpectedResponse = new byte[] { 0x50, 0x01 };
+            if (!sessionSwitchResponse.Take(2).SequenceEqual(sessionExpectedResponse))
+            {
+                Console.WriteLine($"Failed to switch session : target responded with [{BitUtility.BytesToHex(sessionSwitchResponse, true)}]");
+                return false;
+            }
+            return true;
+        }
 
         private static bool GetVariantID(ECUConnection connection, out int variantId) 
         {


### PR DESCRIPTION
If we have connected to an ecu by double clicking on `Initiate Contact` we still need a way to go back to default session.
Could you bind the `ExitDiagnosticSession` to an handler to double click again or somthing else?