### PR TITLE
Fix sorting in RunDiagForm

### DIFF
--- a/Caesar/Diogenes/Forms/AboutForm.Designer.cs
+++ b/Caesar/Diogenes/Forms/AboutForm.Designer.cs
@@ -108,6 +108,7 @@ namespace Diogenes
             "Mark James : http://www.famfamfam.com/about/",
             "Brian Humlicek : https://github.com/BrianHumlicek/J2534-Sharp/",
             "s30shiro (しーちゃん) : http://blog.livedoor.jp/s30shiro/",
+            "@VladLupashevskyi (Vladyslav Lupashevskyi)",
             "@N0cynym (@N0cynym)",
             "@Feezex (Сергей)",
             "@rnd-ash (Ashcon Mohseninia)"});

--- a/Caesar/Diogenes/Forms/RunDiagForm.cs
+++ b/Caesar/Diogenes/Forms/RunDiagForm.cs
@@ -79,10 +79,10 @@ namespace Diogenes
         private void PresentDiagService() 
         {
             DataTable dt = new DataTable();
-            dt.Columns.Add("Index", typeof(String));
+            dt.Columns.Add("Index", typeof(int));
             dt.Columns.Add("Name", typeof(String));
-            dt.Columns.Add("Byte Position", typeof(String));
-            dt.Columns.Add("Data Size", typeof(String));
+            dt.Columns.Add("Byte Position", typeof(int));
+            dt.Columns.Add("Data Size", typeof(int));
             dt.Columns.Add("Data Type", typeof(String));
             dt.Columns.Add("Inferred Type", typeof(String));
             dt.Columns.Add("Direction", typeof(String));
@@ -93,12 +93,12 @@ namespace Diogenes
             {
                 DiagPreparation prep = CurrentDiagService.InputPreparations[i];
 
-                dt.Rows.Add(new string[]
+                dt.Rows.Add(new object[]
                 {
-                        listUniqueIndex.ToString(),
+                        listUniqueIndex,
                         prep.Qualifier,
-                        (prep.BitPosition / 8).ToString(),
-                        (prep.SizeInBits / 8).ToString(),
+                        prep.BitPosition / 8,
+                        prep.SizeInBits / 8,
                         prep.ModeConfig.ToString("X"),
                         prep.FieldType.ToString(),
                         "Input",
@@ -113,12 +113,12 @@ namespace Diogenes
                 {
                     DiagPreparation prep = CurrentDiagService.OutputPreparations[i][j];
 
-                    dt.Rows.Add(new string[]
+                    dt.Rows.Add(new object[]
                     {
-                        listUniqueIndex.ToString(),
+                        listUniqueIndex,
                         prep.Qualifier,
-                        (prep.BitPosition / 8).ToString(),
-                        (prep.SizeInBits / 8).ToString(),
+                        prep.BitPosition / 8,
+                        prep.SizeInBits / 8,
                         prep.ModeConfig.ToString("X"),
                         prep.FieldType.ToString(),
                         $"Output ({i})",


### PR DESCRIPTION
Here is the fix for a small issue with sorting in `RunDiagForm` when there are more than 10 elements

![image](https://user-images.githubusercontent.com/17516057/107096757-b8d7a000-680b-11eb-9afe-a6e7ac7512c0.png)
