### PR TITLE
fixes the TESTERPRESENT_MESSAGE in the KW2C3PE protocol #69

### DIFF
--- a/Caesar/CaesarConnection/ComParam/CP.cs
+++ b/Caesar/CaesarConnection/ComParam/CP.cs
@@ -732,6 +732,20 @@ namespace CaesarConnection.ComParam
         /// </summary>
         public static readonly string ModifyTiming = "CP_ModifyTiming";
 
+
+        // Hacks:
+
+
+        /// <summary>
+        /// Session init TX count
+        /// </summary>
+        public static readonly string NONSTANDARD_FUNCTIONAL_INIT_TXCOUNT = "CP_NONSTANDARD_INIT_TXCOUNT";
+
+        /// <summary>
+        /// KW2C3PE: Session testerpresent response required
+        /// </summary>
+        public static readonly string NONSTANDARD_TP_RESPONSEREQUIRED = "CP_NONSTANDARD_TP_RESPONSEREQUIRED";
+
     }
 }
 

--- a/Caesar/CaesarConnection/Protocol/KW2C3PE.cs
+++ b/Caesar/CaesarConnection/Protocol/KW2C3PE.cs
@@ -153,7 +153,7 @@ namespace CaesarConnection.Protocol
                 //{ CP.SWSUPPLIERBLOCK, 1 },
                 //{ CP.SWVERSIONBLOCK, 1 },
 
-                { CP.TESTERPRESENT_MESSAGE, 0x3E01 },
+                { CP.TESTERPRESENT_MESSAGE, 0x3E02 },
                 { CP.TIMEOUTP2CANREACT, 192 },
                 { CP.TIMEOUTB12REQREACT, 192 },
                 { CP.TIMEOUTCFREACT, 192 },

--- a/Caesar/CaesarConnection/Protocol/KW2C3PE.cs
+++ b/Caesar/CaesarConnection/Protocol/KW2C3PE.cs
@@ -216,11 +216,15 @@ namespace CaesarConnection.Protocol
                 //{ CP.SPARE_9, 0 },
                 //{ CP.SPARE_10, 0 },
 
+                // Hacks, nonstandard stuff follows:
 
                 // this value is unofficially added by jg to reduce false timeouts on j2534 devices
                 // uds has this ~130ms period to reduce false timeouts
                 // this value will be remapped to CanTransmissionTime (ASAM)
                 { CP.CAN_TRANSMIT, 130 },
+
+                // Some KW2C3PE devices init by sending 10 92 multiple times
+                { CP.NONSTANDARD_FUNCTIONAL_INIT_TXCOUNT, 1 },
             };
         }
     }

--- a/Caesar/CaesarConnection/Protocol/KW2C3PE.cs
+++ b/Caesar/CaesarConnection/Protocol/KW2C3PE.cs
@@ -153,7 +153,7 @@ namespace CaesarConnection.Protocol
                 //{ CP.SWSUPPLIERBLOCK, 1 },
                 //{ CP.SWVERSIONBLOCK, 1 },
 
-                { CP.TESTERPRESENT_MESSAGE, 0x3E02 },
+                { CP.TESTERPRESENT_MESSAGE, 0x3E01 },
                 { CP.TIMEOUTP2CANREACT, 192 },
                 { CP.TIMEOUTB12REQREACT, 192 },
                 { CP.TIMEOUTCFREACT, 192 },

--- a/Caesar/CaesarConnection/Protocol/UDS.cs
+++ b/Caesar/CaesarConnection/Protocol/UDS.cs
@@ -68,7 +68,7 @@ namespace CaesarConnection.Protocol
                 {
                     // during functional initialization, vediamo transmits session change (10 92) twice. There isn't a comparam for this value
                     Console.WriteLine($"EnterSessionDiagnostic : EcuIsFunctional T: {sw.ElapsedMilliseconds}");
-                    const int FunctionalInitializationSessionInitCount = 2; // FIXME:HARDCODED
+                    int FunctionalInitializationSessionInitCount = (int)ComParameters.GetParameterOrDefault(CP.NONSTANDARD_FUNCTIONAL_INIT_TXCOUNT, 2);
                     for (int i = 0; i < FunctionalInitializationSessionInitCount; i++)
                     {
                         Console.WriteLine($"Index: {i}, FunctionalInitializationSessionInitCount: {FunctionalInitializationSessionInitCount} T: {sw.ElapsedMilliseconds}");

--- a/Caesar/Diogenes/ComParamQuirks.cs
+++ b/Caesar/Diogenes/ComParamQuirks.cs
@@ -1,0 +1,28 @@
+﻿using CaesarConnection.ComParam;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Diogenes
+{
+    public class ComParamQuirks
+    {
+        public static Dictionary<string, int> GetQuirksForTarget(string ecuQualifier, string ifaceQualifier) 
+        {
+            var quirks = new Dictionary<string, int>();
+
+            if (ecuQualifier == "KI211") 
+            {
+                if (ifaceQualifier == "HSCAN_KW2C3PE_500")
+                {
+                    quirks.Add(CP.NONSTANDARD_FUNCTIONAL_INIT_TXCOUNT, 5);
+                    quirks.Add(CP.TESTERPRESENT_MESSAGE, 0x3E01);
+                }
+            }
+
+            return quirks;
+        }
+    }
+}

--- a/Caesar/Diogenes/Forms/MainForm.cs
+++ b/Caesar/Diogenes/Forms/MainForm.cs
@@ -234,6 +234,23 @@ namespace Diogenes.Forms
                     continue;
                 }
                 var comParams = iface.CommunicationParameters.ToDictionary(t => t.ParamName, t => t.ComParamValue);
+                
+                // check if there are quirks to be applied for the currently selected target
+                var quirks = ComParamQuirks.GetQuirksForTarget(DiogenesSharedContext.Singleton.PrimaryEcu.Qualifier, iface.Qualifier);
+
+                // if available, apply, overriding prior values from the CBF if duplicates are found
+                foreach (var quirk in quirks) 
+                {
+                    if (comParams.ContainsKey(quirk.Key))
+                    {
+                        comParams[quirk.Key] = quirk.Value;
+                    }
+                    else 
+                    {
+                        comParams.Add(quirk.Key, quirk.Value);
+                    }
+                }
+
                 comParams.ToList().ForEach(x => DiogenesSharedContext.Singleton.PreConnectParameters.Add(new DiogenesSharedContext.RawComParam { Name = x.Key, Value = x.Value }));
             }
 


### PR DESCRIPTION
Fixes the TESTERPRESENT_MESSAGE in the KW2C3PE protocol #69 by changing it from `3E 01` to `3E 02`.