### PR TITLE
fix: clarify memory address labels - change "source" and "destination" to more sensible labels

### DIFF
--- a/Caesar/Diogenes/Forms/MemoryEditorView.Designer.cs
+++ b/Caesar/Diogenes/Forms/MemoryEditorView.Designer.cs
@@ -1,4 +1,4 @@
-﻿
+
 namespace Diogenes.Forms
 {
     partial class MemoryEditorView
@@ -82,7 +82,7 @@ namespace Diogenes.Forms
             this.groupBox1.Size = new System.Drawing.Size(244, 52);
             this.groupBox1.TabIndex = 0;
             this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Source Address (Hex)";
+            this.groupBox1.Text = "Start Address (Hex)";
             // 
             // txtSrcAddress
             // 
@@ -389,7 +389,7 @@ namespace Diogenes.Forms
             this.groupBox2.Size = new System.Drawing.Size(244, 76);
             this.groupBox2.TabIndex = 1;
             this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "Destination (Hex)";
+            this.groupBox2.Text = "End Address (Hex)";
             // 
             // rbSize
             // 


### PR DESCRIPTION
This confused me a lot, I spent a long time looking for memory dump functionality because I KNEW this program had it. Turns out I was staring at the whole time! Source and destination imply copy/moving which I wouldn't associate with reading. 